### PR TITLE
Fix a meson warning

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -12,7 +12,7 @@ gnome.compile_resources('teleprompter',
 python = import('python')
 
 conf = configuration_data()
-conf.set('PYTHON', python.find_installation('python3').path())
+conf.set('PYTHON', python.find_installation('python3').full_path())
 conf.set('VERSION', meson.project_version())
 conf.set('localedir', join_paths(get_option('prefix'), get_option('localedir')))
 conf.set('pkgdatadir', pkgdatadir)


### PR DESCRIPTION
"WARNING: Project targets '>= 0.62.0' but uses feature deprecated since '0.55.0': ExternalProgram.path.
use ExternalProgram.full_path() instead"