### PR TITLE
Fix typos

### DIFF
--- a/data/io.github.nokse22.teleprompter.appdata.xml.in
+++ b/data/io.github.nokse22.teleprompter.appdata.xml.in
@@ -35,8 +35,8 @@
 			  <ul>
 					<li>Fixed some bugs</li>
 			    <li>Improved some icons</li>
-			    <li>Added Spanish tranlation</li>
-			    <li>Added Russian tranlation (Сергей Ворон)</li>
+			    <li>Added Spanish translation</li>
+			    <li>Added Russian translation (Сергей Ворон)</li>
 			    <li>When the end is reached it stops</li>
 				</ul>
 		  </description>

--- a/src/window.py
+++ b/src/window.py
@@ -292,7 +292,7 @@ def  on_text_pasted(text_buffer, clipboard, self):
     apply_text_tags(self)
     updateFont(self)
 
-def on_text_inserted(text_buffer, loc, text, lenght, self):
+def on_text_inserted(text_buffer, loc, text, length, self):
     apply_text_tags(self)
     updateFont(self)
     start = self.text_buffer.get_start_iter()


### PR DESCRIPTION
Found via `codespell`