### PR TITLE
Added menu entries and keyboard shortcut hints with translations

### DIFF
--- a/po/es.po
+++ b/po/es.po
@@ -186,6 +186,12 @@ msgstr ""
 msgid "_Preferences"
 msgstr "_Preferencias"
 
+msgid "Fullscreen"
+msgstr "Pantalla Completa"
+
+msgid "Play/Pause"
+msgstr "Reproducción/Pausa"
+
 #: src/window.ui:270
 msgid "_Keyboard Shortcuts"
 msgstr "_Atajos de teclado"

--- a/po/fr.po
+++ b/po/fr.po
@@ -193,6 +193,12 @@ msgstr ""
 msgid "_Preferences"
 msgstr "_Préférences"
 
+msgid "Fullscreen"
+msgstr "Plein écran"
+
+msgid "Play/Pause"
+msgstr "Lecture/Pause"
+
 #: src/window.ui:270
 msgid "_Keyboard Shortcuts"
 msgstr "_Raccourcis clavier"

--- a/src/gtk/help-overlay.ui
+++ b/src/gtk/help-overlay.ui
@@ -27,6 +27,18 @@
                 <property name="action-name">app.quit</property>
               </object>
             </child>
+            <child>
+              <object class="GtkShortcutsShortcut">
+                <property name="title" translatable="yes" context="shortcut window">Play/Pause</property>
+                <property name="action-name">app.play</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkShortcutsShortcut">
+                <property name="title" translatable="yes" context="shortcut window">Fullscreen</property>
+                <property name="action-name">app.fullscreen</property>
+              </object>
+            </child>
           </object>
         </child>
       </object>

--- a/src/window.ui
+++ b/src/window.ui
@@ -267,6 +267,14 @@ The font, color of the text and highlights can be customized.
         <attribute name="action">app.preferences</attribute>
       </item>
       <item>
+        <attribute name="label" translatable="yes">Fullscreen</attribute>
+        <attribute name="action">app.fullscreen</attribute>
+      </item>
+      <item>
+        <attribute name="label" translatable="yes">Play/Pause</attribute>
+        <attribute name="action">app.play</attribute>
+      </item>
+      <item>
         <attribute name="label" translatable="yes">_Keyboard Shortcuts</attribute>
         <attribute name="action">win.show-help-overlay</attribute>
       </item>


### PR DESCRIPTION
Shows the accelerator keys in the "Shortcuts" window, and also in the menu on the top-right. The texts are translated into Spanish and French.