### PR TITLE
appdata: `translate=no` properties

### DIFF
--- a/data/io.github.nokse22.teleprompter.appdata.xml.in
+++ b/data/io.github.nokse22.teleprompter.appdata.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <component type="desktop">
 	<id>io.github.nokse22.teleprompter.desktop</id>
-	<name translatable="no">Teleprompter</name>
+	<name translate="no">Teleprompter</name>
 	<metadata_license>CC0-1.0</metadata_license>
 	<project_license>GPL-3.0-or-later</project_license>
 	<description>
@@ -13,7 +13,7 @@
 	<content_rating type="oars-1.1" />
 
   <developer id="io.github.nokse22">
-    <name translatable="no">Nokse</name>
+    <name translate="no">Nokse</name>
   </developer>
 
 	  <recommends>
@@ -42,13 +42,13 @@
 
   <releases>
     <release version="0.1.8" date="2024-03-26">
-		  <description translatable="no">
+		  <description translate="no">
 			  <p>Updated runtime</p>
 		    <p>Used latest Libadwaita widgets</p>
 		  </description>
 	  </release>
     <release version="0.1.7" date="2024-03-10">
-		  <description translatable="no">
+		  <description translate="no">
 			  <ul>
           <li>Updated summary</li>
           <li>Added branding colors</li>
@@ -60,7 +60,7 @@
 		  </description>
 	  </release>
     <release version="0.1.6" date="2023-12-12">
-		  <description translatable="no">
+		  <description translate="no">
 			  <ul>
           <li>Improved adaptability for mobile devices</li>
           <li>Updated screenshots</li>
@@ -70,7 +70,7 @@
 		  </description>
 	  </release>
     <release version="0.1.5" date="2023-08-15">
-		  <description translatable="no">
+		  <description translate="no">
 			  <ul>
 					<li>Added Dutch translation (Heimen Stoffels)</li>
 			    <li>Fixed bugs</li>
@@ -78,7 +78,7 @@
 		  </description>
 	  </release>
     <release version="0.1.4" date="2023-07-22">
-		  <description translatable="no">
+		  <description translate="no">
 			  <ul>
 					<li>Settings are applied right away</li>
 			    <li>Fixed some typos</li>
@@ -87,7 +87,7 @@
 		  </description>
 	  </release>
     <release version="0.1.3" date="2023-07-09">
-		  <description translatable="no">
+		  <description translate="no">
 			  <ul>
 					<li>Fixed some bugs</li>
 			    <li>Improved some icons</li>
@@ -98,7 +98,7 @@
 		  </description>
 	  </release>
 	  <release version="0.1.2" date="2023-06-16">
-		  <description translatable="no">
+		  <description translate="no">
 			  <ul>
 					<li>New icon</li>
 					<li>Fixed highlighting bugs</li>
@@ -113,7 +113,7 @@
 		  </description>
 	  </release>
     <release version="0.1.1" date="2023-06-11">
-		  <description translatable="no">
+		  <description translate="no">
 			  <p>First release!</p>
 		  </description>
 	  </release>


### PR DESCRIPTION
It appears that the appstream project no longer supports `translatable=no` properties, and gettext extract the `translatable=no` marked strings as translatable.

I opened an issue to inform about the situation, but `translatable=no` properties are not accepted by developers. You can find the issue here: https://github.com/ximion/appstream/issues/623

**Please test your script or string extraction process before merging this PR.**

> In MetaInfo files, each individual paragraph of a description
> (or enumerated entry) is translated individually, however,
> you can only exclude the complete block from being translated
> by adding `translate="no"` to the description element.

Source: https://freedesktop.org/software/appstream/docs/sect-Quickstart-Translation.html